### PR TITLE
Reuse Process effect

### DIFF
--- a/src/Effectful/Process/Typed.hs
+++ b/src/Effectful/Process/Typed.hs
@@ -71,23 +71,27 @@ import System.Process.Typed as Reexport hiding
 import Data.ByteString.Lazy (ByteString)
 import qualified System.Process.Typed as PT
 
-import Effectful.Internal.Effect
-import Effectful.Internal.Monad
-import Effectful (Dispatch(..), DispatchOf)
-import Effectful.Dispatch.Static (SideEffects(..))
+import Effectful
+import qualified Effectful.Process
+import Effectful.Dispatch.Static
 
 #if ! MIN_VERSION_typed_process(0,2,8)
 import System.Exit (ExitCode(..))
 #endif
 
--- | An effect for running child processes using the @typed-process@ library.
-data TypedProcess :: Effect
+----------------------------------------
+-- Effect & Handler
 
-type instance DispatchOf TypedProcess = 'Static 'WithSideEffects
-data instance StaticRep TypedProcess = TypedProcess
+-- | We provide a type synonym for the 'Effectful.Process.Process' effect since
+-- it clashes with 'PT.Process' type of @typed-process@.
+type TypedProcess = Effectful.Process.Process
 
+-- | This is merely an alias for 'Effectful.Process.runProcess' since that name
+-- clashes with 'runProcess', i.e.:
+--
+-- > runTypedProcess = Effectful.Process.runProcess
 runTypedProcess :: IOE :> es => Eff (TypedProcess : es) a -> Eff es a
-runTypedProcess = evalStaticRep TypedProcess
+runTypedProcess = Effectful.Process.runProcess
 
 ----------------------------------------
 -- Launch a process

--- a/typed-process-effectful.cabal
+++ b/typed-process-effectful.cabal
@@ -20,10 +20,10 @@ bug-reports:
   https://github.com/haskell-effectful/typed-process-effectful/issues
 
 author:             Dominik Peteler
-maintainer:         Dominik Peteler
+maintainer:         hackage+typed-process-effectful@with-h.at
 license:            BSD-3-Clause
 build-type:         Simple
-extra-source-files:
+extra-doc-files:
   CHANGELOG.md
   LICENSE.md
   README.md

--- a/typed-process-effectful.cabal
+++ b/typed-process-effectful.cabal
@@ -53,6 +53,7 @@ library
   build-depends:
     , base            >=4.14  && <5
     , bytestring      <0.12
+    , effectful       >=2.0   && <2.3
     , effectful-core  >=2.0   && <2.3
     , typed-process   >=0.2.5 && <0.3
 


### PR DESCRIPTION
Instead of having a dedicated `TypedProcess` effect with an own representation we provide a type synonym and an alias for `runProcess` for convenience. Those are necessary since the names `Process` and `runProcess` are clash with the names of the type/function found in `typed-process`.

Fixes #3 